### PR TITLE
Fix RuntimeError at /feed

### DIFF
--- a/xkcd-feed.rb
+++ b/xkcd-feed.rb
@@ -2,7 +2,7 @@ require 'open-uri'
 require 'sinatra'
 
 get '/feed' do
-	url = 'http://xkcd.com/rss.xml'
+	url = 'https://xkcd.com/rss.xml'
 	match = /(&lt;img.*? alt="(?<alt>.*?)".*?&gt;)/
 	replace = "\n\\0\n&lt;p&gt;alt-text: \\k<alt>&lt;/p&gt;\n"
 	open(url) do |page|


### PR DESCRIPTION
XKCD must have switched to requiring HTTPS.

    RuntimeError at /feed
    redirection forbidden: http://xkcd.com/rss.xml -> https://xkcd.com/rss.xml